### PR TITLE
[WIP] [Monitoring] APM UI specifics

### DIFF
--- a/x-pack/plugins/monitoring/public/components/apm/instance/instance.js
+++ b/x-pack/plugins/monitoring/public/components/apm/instance/instance.js
@@ -9,8 +9,16 @@ import { MonitoringTimeseriesContainer } from '../../chart';
 import { EuiFlexGrid, EuiFlexItem, EuiSpacer, EuiPage, EuiPageBody } from '@elastic/eui';
 import { Status } from './status';
 
-export function ApmServerInstance({ summary, ...props }) {
+export function ApmServerInstance({ summary, metrics, ...props }) {
   const metricsToShow = [
+    metrics.apm_cpu,
+    metrics.apm_os_load,
+    metrics.apm_output_events_rate,
+    metrics.apm_requests,
+    metrics.apm_incoming_requests_size,
+    metrics.apm_memory,
+    metrics.apm_transformations,
+    metrics.apm_responses_success_failure
   ];
 
   return (

--- a/x-pack/plugins/monitoring/public/components/apm/instance/status.js
+++ b/x-pack/plugins/monitoring/public/components/apm/instance/status.js
@@ -5,12 +5,19 @@
  */
 
 import React, { Fragment } from 'react';
+import moment from 'moment';
 import { SummaryStatus } from '../../summary_status';
 import { ApmStatusIcon } from '../status_icon';
+import { formatMetric } from '../../../lib/format_number';
+import { formatTimestampToDuration } from '../../../../common';
 
 export function Status({ stats }) {
   const {
     name,
+    output,
+    version,
+    uptime,
+    timeOfLastEvent,
   } = stats;
 
   const metrics = [
@@ -19,6 +26,26 @@ export function Status({ stats }) {
       value: name,
       dataTestSubj: 'name'
     },
+    {
+      label: 'Output',
+      value: output,
+      dataTestSubj: 'output'
+    },
+    {
+      label: 'Version',
+      value: version,
+      dataTestSubj: 'version'
+    },
+    {
+      label: 'Uptime',
+      value: formatMetric(uptime, 'time_since'),
+      dataTestSubj: 'uptime'
+    },
+    {
+      label: 'Last Event',
+      value: formatTimestampToDuration(+moment(timeOfLastEvent), 'since') + ' ago',
+      dataTestSubj: 'timeOfLastEvent',
+    }
   ];
 
   const IconComponent = ({ status }) => (

--- a/x-pack/plugins/monitoring/public/components/apm/instances/instances.js
+++ b/x-pack/plugins/monitoring/public/components/apm/instances/instances.js
@@ -13,10 +13,14 @@ import {
 } from '@kbn/ui-framework/components';
 import { EuiLink } from '@elastic/eui';
 import { Status } from './status';
+import { SORT_ASCENDING, SORT_DESCENDING } from '../../../../common/constants';
 
 
 const filterFields = [ 'beat.name' ];
 const columns = [
+  { title: 'Name', sortKey: 'beat.name', sortOrder: SORT_ASCENDING },
+  { title: 'Version', sortKey: 'beat.version', sortOrder: SORT_ASCENDING },
+  { title: 'Error Count', sortKey: 'errorCount', sortOrder: SORT_DESCENDING },
 ];
 const instanceRowFactory = (goToInstance) => {
   return function KibanaRow(props) {
@@ -29,6 +33,26 @@ const instanceRowFactory = (goToInstance) => {
               data-test-subj={`apmLink-${props.beat.name}`}
             >
               { props.beat.name }
+            </EuiLink>
+          </div>
+        </KuiTableRowCell>
+        <KuiTableRowCell>
+          <div className="monitoringTableCell__version">
+            <EuiLink
+              onClick={goToInstance.bind(null, get(props, 'beat.uuid'))}
+              data-test-subj={`apmLink-${props.beat.version}`}
+            >
+              { props.beat.version }
+            </EuiLink>
+          </div>
+        </KuiTableRowCell>
+        <KuiTableRowCell>
+          <div className="monitoringTableCell__number">
+            <EuiLink
+              onClick={goToInstance.bind(null, get(props, 'beat.uuid'))}
+              data-test-subj={`apmLink-errors`}
+            >
+              { props.errorCount }
             </EuiLink>
           </div>
         </KuiTableRowCell>

--- a/x-pack/plugins/monitoring/public/components/apm/instances/status.js
+++ b/x-pack/plugins/monitoring/public/components/apm/instances/status.js
@@ -9,6 +9,7 @@ import moment from 'moment';
 import { SummaryStatus } from '../../summary_status';
 import { ApmStatusIcon } from '../status_icon';
 import { formatMetric } from '../../../lib/format_number';
+import { formatTimestampToDuration } from '../../../../common';
 
 export function Status({ stats }) {
   const {
@@ -38,7 +39,7 @@ export function Status({ stats }) {
     },
     {
       label: 'Last Event',
-      value: formatMetric(+moment(timeOfLastEvent), 'time_since_time', 'ago'),
+      value: formatTimestampToDuration(+moment(timeOfLastEvent), 'since') + ' ago',
       dataTestSubj: 'timeOfLastEvent',
     }
   ];

--- a/x-pack/plugins/monitoring/public/components/apm/instances/status.js
+++ b/x-pack/plugins/monitoring/public/components/apm/instances/status.js
@@ -38,7 +38,7 @@ export function Status({ stats }) {
     },
     {
       label: 'Last Event',
-      value: formatMetric(+moment(timeOfLastEvent), 'time_since2', 'ago'),
+      value: formatMetric(+moment(timeOfLastEvent), 'time_since_time', 'ago'),
       dataTestSubj: 'timeOfLastEvent',
     }
   ];

--- a/x-pack/plugins/monitoring/public/components/apm/instances/status.js
+++ b/x-pack/plugins/monitoring/public/components/apm/instances/status.js
@@ -5,15 +5,42 @@
  */
 
 import React, { Fragment } from 'react';
+import moment from 'moment';
 import { SummaryStatus } from '../../summary_status';
 import { ApmStatusIcon } from '../status_icon';
+import { formatMetric } from '../../../lib/format_number';
 
 export function Status({ stats }) {
   const {
+    apms: {
+      total
+    },
+    bytesSent,
+    totalEvents,
+    timeOfLastEvent,
   } = stats;
 
   const metrics = [
-
+    {
+      label: 'Servers',
+      value: total,
+      dataTestSubj: 'total'
+    },
+    {
+      label: 'Bytes Sent',
+      value: formatMetric(bytesSent, 'bytes'),
+      dataTestSubj: 'bytesSent'
+    },
+    {
+      label: 'Total Events',
+      value: formatMetric(totalEvents, '0.[0]a'),
+      dataTestSubj: 'totalEvents'
+    },
+    {
+      label: 'Last Event',
+      value: formatMetric(+moment(timeOfLastEvent), 'time_since2', 'ago'),
+      dataTestSubj: 'timeOfLastEvent',
+    }
   ];
 
   const IconComponent = ({ status }) => (

--- a/x-pack/plugins/monitoring/public/components/apm/overview/index.js
+++ b/x-pack/plugins/monitoring/public/components/apm/overview/index.js
@@ -18,9 +18,18 @@ import { Status } from '../instances/status';
 
 export function ApmOverview({
   stats,
+  metrics,
   ...props
 }) {
   const seriesToShow = [
+    metrics.apm_cpu,
+    metrics.apm_os_load,
+    metrics.apm_output_events_rate,
+    metrics.apm_requests,
+    metrics.apm_incoming_requests_size,
+    metrics.apm_memory,
+    metrics.apm_transformations,
+    metrics.apm_responses_success_failure
   ];
 
   const charts = seriesToShow.map((data, index) => (

--- a/x-pack/plugins/monitoring/public/components/cluster/overview/apm_panel.js
+++ b/x-pack/plugins/monitoring/public/components/cluster/overview/apm_panel.js
@@ -22,7 +22,7 @@ import {
 } from '@elastic/eui';
 
 export function ApmPanel(props) {
-  if (!get(props, 'beats.total', 0) > 0) {
+  if (!get(props, 'apms.total', 0) > 0) {
     return null;
   }
 
@@ -48,11 +48,11 @@ export function ApmPanel(props) {
             <EuiHorizontalRule margin="m" />
             <EuiDescriptionList type="column">
               <EuiDescriptionListTitle>Total Events</EuiDescriptionListTitle>
-              <EuiDescriptionListDescription data-test-subj="beatsTotalEvents">
+              <EuiDescriptionListDescription data-test-subj="apmsTotalEvents">
                 {formatMetric(props.totalEvents, '0.[0]a')}
               </EuiDescriptionListDescription>
               <EuiDescriptionListTitle>Bytes Sent</EuiDescriptionListTitle>
-              <EuiDescriptionListDescription data-test-subj="beatsBytesSent">
+              <EuiDescriptionListDescription data-test-subj="apmsBytesSent">
                 {formatMetric(props.bytesSent, 'byte')}
               </EuiDescriptionListDescription>
             </EuiDescriptionList>
@@ -64,10 +64,10 @@ export function ApmPanel(props) {
               <h3>
                 <EuiLink
                   onClick={goToInstances}
-                  aria-label={`Apm Instances: ${props.beats.total}`}
+                  aria-label={`Apm Instances: ${props.apms.total}`}
                   data-test-subj="apmListing"
                 >
-                  APM Servers: <span data-test-subj="beatsTotal">{props.beats.total}</span>
+                  APM Servers: <span data-test-subj="apmsTotal">{props.apms.total}</span>
                 </EuiLink>
               </h3>
             </EuiTitle>

--- a/x-pack/plugins/monitoring/public/lib/format_number.js
+++ b/x-pack/plugins/monitoring/public/lib/format_number.js
@@ -30,8 +30,6 @@ export function formatNumber(num, which) {
   switch (which) {
     case 'time_since':
       return moment(moment() - num).from(moment(), true);
-    case 'time_since_time':
-      return moment().from(num, true);
     case 'time':
       return moment(num).format('H:mm:ss');
     case 'int_commas':

--- a/x-pack/plugins/monitoring/public/lib/format_number.js
+++ b/x-pack/plugins/monitoring/public/lib/format_number.js
@@ -30,6 +30,8 @@ export function formatNumber(num, which) {
   switch (which) {
     case 'time_since':
       return moment(moment() - num).from(moment(), true);
+    case 'time_since_time':
+      return moment().from(num, true);
     case 'time':
       return moment(num).format('H:mm:ss');
     case 'int_commas':

--- a/x-pack/plugins/monitoring/server/lib/apm/_apm_stats.js
+++ b/x-pack/plugins/monitoring/server/lib/apm/_apm_stats.js
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import { capitalize, get } from 'lodash';
+import { get } from 'lodash';
 
 export const getDiffCalculation = (max, min) => {
   // no need to test max >= 0, but min <= 0 which is normal for a derivative after restart
@@ -102,17 +102,7 @@ export const apmUuidsAgg = maxBucketSize => ({
 });
 
 export const apmAggResponseHandler = response => {
-  const buckets = get(response, 'aggregations.types.buckets', []);
-  const beatTotal = get(response, 'aggregations.total.value', null);
-  const beatTypes = buckets.reduce((types, typeBucket) => {
-    return [
-      ...types,
-      {
-        type: capitalize(typeBucket.key),
-        count: get(typeBucket, 'uuids.buckets.length'),
-      }
-    ];
-  }, []);
+  const apmTotal = get(response, 'aggregations.total.value', null);
 
   const eventsTotalMax = get(response, 'aggregations.max_events_total.value', null);
   const eventsTotalMin = get(response, 'aggregations.min_events_total.value', null);
@@ -120,8 +110,7 @@ export const apmAggResponseHandler = response => {
   const bytesSentMin = get(response, 'aggregations.min_bytes_sent_total.value', null);
 
   return {
-    beatTotal,
-    beatTypes,
+    apmTotal,
     totalEvents: getDiffCalculation(eventsTotalMax, eventsTotalMin),
     bytesSent: getDiffCalculation(bytesSentMax, bytesSentMin),
   };

--- a/x-pack/plugins/monitoring/server/lib/apm/_get_time_of_last_event.js
+++ b/x-pack/plugins/monitoring/server/lib/apm/_get_time_of_last_event.js
@@ -1,0 +1,43 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { get } from 'lodash';
+import { createApmQuery } from './create_apm_query';
+import { BeatsClusterMetric } from '../metrics';
+
+export async function getTimeOfLastEvent({ req, callWithRequest, apmIndexPattern, start, end, clusterUuid }) {
+  const params = {
+    index: apmIndexPattern,
+    size: 1,
+    ignoreUnavailable: true,
+    body: {
+      _source: ['timestamp'],
+      sort: [{
+        timestamp: {
+          order: 'desc'
+        }
+      }],
+      query: createApmQuery({
+        start,
+        end,
+        clusterUuid,
+        metric: BeatsClusterMetric.getMetricFields(), // override default of BeatMetric.getMetricFields
+        filters: [
+          {
+            range: {
+              'beats_stats.metrics.libbeat.output.events.acked': {
+                gt: 0,
+              }
+            }
+          }
+        ],
+      }),
+    }
+  };
+
+  const response = await callWithRequest(req, 'search', params);
+  return get(response, 'hits.hits[0]._source.timestamp');
+}

--- a/x-pack/plugins/monitoring/server/lib/apm/get_apm_info.js
+++ b/x-pack/plugins/monitoring/server/lib/apm/get_apm_info.js
@@ -1,0 +1,111 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { get, capitalize } from 'lodash';
+import { checkParam } from '../error_missing_required';
+import { createQuery } from '../create_query';
+import { getDiffCalculation } from '../beats/_beats_stats';
+import { ApmMetric } from '../metrics';
+import { getTimeOfLastEvent } from './_get_time_of_last_event';
+
+export function handleResponse(response, apmUuid) {
+  const firstStats = get(response, 'hits.hits[0].inner_hits.first_hit.hits.hits[0]._source.beats_stats');
+  const stats = get(response, 'hits.hits[0]._source.beats_stats');
+
+  const eventsTotalFirst = get(firstStats, 'metrics.libbeat.pipeline.events.total', null);
+  const eventsEmittedFirst = get(firstStats, 'metrics.libbeat.pipeline.events.published', null);
+  const eventsDroppedFirst = get(firstStats, 'metrics.libbeat.pipeline.events.dropped', null);
+  const bytesWrittenFirst = get(firstStats, 'metrics.libbeat.output.write.bytes', null);
+
+  const eventsTotalLast = get(stats, 'metrics.libbeat.pipeline.events.total', null);
+  const eventsEmittedLast = get(stats, 'metrics.libbeat.pipeline.events.published', null);
+  const eventsDroppedLast = get(stats, 'metrics.libbeat.pipeline.events.dropped', null);
+  const bytesWrittenLast = get(stats, 'metrics.libbeat.output.write.bytes', null);
+
+  return {
+    uuid: apmUuid,
+    transportAddress: get(stats, 'beat.host', null),
+    version: get(stats, 'beat.version', null),
+    name: get(stats, 'beat.name', null),
+    type: capitalize(get(stats, 'beat.type')) || null,
+    output: capitalize(get(stats, 'metrics.libbeat.output.type')) || null,
+    configReloads: get(stats, 'metrics.libbeat.config.reloads', null),
+    uptime: get(stats, 'metrics.beat.info.uptime.ms', null),
+    eventsTotal: getDiffCalculation(eventsTotalLast, eventsTotalFirst),
+    eventsEmitted: getDiffCalculation(eventsEmittedLast, eventsEmittedFirst),
+    eventsDropped: getDiffCalculation(eventsDroppedLast, eventsDroppedFirst),
+    bytesWritten: getDiffCalculation(bytesWrittenLast, bytesWrittenFirst),
+  };
+}
+
+export async function getApmInfo(req, apmIndexPattern, { clusterUuid, apmUuid, start, end }) {
+  checkParam(apmIndexPattern, 'apmIndexPattern in beats/getBeatSummary');
+
+  const filters = [
+    { term: { 'beats_stats.beat.uuid': apmUuid } },
+    { term: { 'beats_stats.beat.type': 'apm-server' } }
+  ];
+  const params = {
+    index: apmIndexPattern,
+    size: 1,
+    ignoreUnavailable: true,
+    filterPath: [
+      'hits.hits._source.beats_stats.beat.host',
+      'hits.hits._source.beats_stats.beat.version',
+      'hits.hits._source.beats_stats.beat.name',
+      'hits.hits._source.beats_stats.beat.type',
+      'hits.hits._source.beats_stats.metrics.libbeat.output.type',
+      'hits.hits._source.beats_stats.metrics.libbeat.pipeline.events.published',
+      'hits.hits._source.beats_stats.metrics.libbeat.pipeline.events.total',
+      'hits.hits._source.beats_stats.metrics.libbeat.pipeline.events.dropped',
+      'hits.hits._source.beats_stats.metrics.libbeat.output.write.bytes',
+      'hits.hits._source.beats_stats.metrics.libbeat.config.reloads',
+      'hits.hits._source.beats_stats.metrics.beat.info.uptime.ms',
+      'hits.hits.inner_hits.first_hit.hits.hits._source.beats_stats.metrics.libbeat.pipeline.events.published',
+      'hits.hits.inner_hits.first_hit.hits.hits._source.beats_stats.metrics.libbeat.pipeline.events.total',
+      'hits.hits.inner_hits.first_hit.hits.hits._source.beats_stats.metrics.libbeat.pipeline.events.dropped',
+      'hits.hits.inner_hits.first_hit.hits.hits._source.beats_stats.metrics.libbeat.output.write.bytes',
+    ],
+    body: {
+      sort: { timestamp: { order: 'desc' } },
+      query: createQuery({
+        start,
+        end,
+        clusterUuid,
+        metric: ApmMetric.getMetricFields(),
+        filters
+      }),
+      collapse: {
+        field: 'beats_stats.metrics.beat.info.ephemeral_id', // collapse on ephemeral_id to handle restart
+        inner_hits: {
+          name: 'first_hit',
+          size: 1,
+          sort: { 'beats_stats.timestamp': 'asc' }
+        }
+      }
+    }
+  };
+
+  const { callWithRequest } = req.server.plugins.elasticsearch.getCluster('monitoring');
+
+  const [response, timeOfLastEvent] = await Promise.all([
+    callWithRequest(req, 'search', params),
+    getTimeOfLastEvent({
+      req,
+      callWithRequest,
+      apmIndexPattern,
+      start,
+      end,
+      clusterUuid
+    })
+  ]);
+
+  const formattedResponse = handleResponse(response, apmUuid);
+  return {
+    ...formattedResponse,
+    timeOfLastEvent,
+  };
+}

--- a/x-pack/plugins/monitoring/server/lib/apm/get_apms.js
+++ b/x-pack/plugins/monitoring/server/lib/apm/get_apms.js
@@ -1,0 +1,82 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { get, sum } from 'lodash';
+import moment from 'moment';
+import { checkParam } from '../error_missing_required';
+import { createQuery } from '../create_query';
+import { calculateAvailability } from '../calculate_availability';
+import { ApmMetric } from '../metrics';
+
+/*
+ * Get detailed info for APMs in the cluster
+ * for APM listing page
+ * For each instance:
+ *  - name
+ *  - status
+ *  - memory
+ *  - os load average
+ *  - requests
+ *  - response times
+ */
+export function getApms(req, apmIndexPattern, { clusterUuid }) {
+  checkParam(apmIndexPattern, 'apmIndexPattern in getApms');
+
+  const config = req.server.config();
+  const start = moment.utc(req.payload.timeRange.min).valueOf();
+  const end = moment.utc(req.payload.timeRange.max).valueOf();
+
+  const params = {
+    index: apmIndexPattern,
+    size: config.get('xpack.monitoring.max_bucket_size'),
+    ignoreUnavailable: true,
+    body: {
+      query: createQuery({
+        type: 'beats_stats',
+        start,
+        end,
+        clusterUuid,
+        metric: ApmMetric.getMetricFields(),
+        filters: [
+          {
+            bool: {
+              should: [
+                { term: { 'beats_stats.beat.type': 'apm-server' } }
+              ]
+            }
+          }
+        ]
+      }),
+      collapse: {
+        field: 'beats_stats.beat.uuid'
+      },
+      sort: [
+        { timestamp: { order: 'desc' } }
+      ],
+      _source: [
+        'timestamp',
+        'beats_stats.beat.*',
+        'beats_stats.metrics.apm-server.server.response.errors.*',
+      ]
+    }
+  };
+
+  const { callWithRequest } = req.server.plugins.elasticsearch.getCluster('monitoring');
+  return callWithRequest(req, 'search', params)
+    .then(resp => {
+      const instances = get(resp, 'hits.hits', []);
+
+      return instances.map(hit => {
+        const beatStats = get(hit, '_source.beats_stats');
+        const errorCount = sum(Object.values(get(beatStats, 'metrics.apm-server.server.response.errors')));
+        return {
+          ...beatStats,
+          errorCount,
+          availability: calculateAvailability(get(hit, '_source.timestamp'))
+        };
+      });
+    });
+}

--- a/x-pack/plugins/monitoring/server/lib/apm/get_apms_for_clusters.js
+++ b/x-pack/plugins/monitoring/server/lib/apm/get_apms_for_clusters.js
@@ -67,8 +67,6 @@ export function getApmsForClusters(req, apmIndexPattern, clusters) {
       })
     ]);
 
-    console.log('timeOfLastEvent', timeOfLastEvent);
-
     const formattedResponse = handleResponse(clusterUuid, response);
     return {
       ...formattedResponse,

--- a/x-pack/plugins/monitoring/server/lib/apm/get_apms_for_clusters.js
+++ b/x-pack/plugins/monitoring/server/lib/apm/get_apms_for_clusters.js
@@ -10,15 +10,14 @@ import { ApmMetric } from '../metrics';
 import { apmAggResponseHandler, apmUuidsAgg, apmAggFilterPath } from './_apm_stats';
 
 export function handleResponse(clusterUuid, response) {
-  const { beatTotal, beatTypes, totalEvents, bytesSent } = apmAggResponseHandler(response);
+  const { apmTotal, totalEvents, bytesSent } = apmAggResponseHandler(response);
 
   // combine stats
   const stats = {
     totalEvents,
     bytesSent,
-    beats: {
-      total: beatTotal,
-      types: beatTypes,
+    apms: {
+      total: apmTotal,
     }
   };
 

--- a/x-pack/plugins/monitoring/server/lib/apm/get_apms_for_clusters.js
+++ b/x-pack/plugins/monitoring/server/lib/apm/get_apms_for_clusters.js
@@ -75,6 +75,5 @@ export function getApmsForClusters(req, apmIndexPattern, clusters) {
         timeOfLastEvent,
       }
     };
-
   }));
 }

--- a/x-pack/plugins/monitoring/server/lib/apm/get_stats.js
+++ b/x-pack/plugins/monitoring/server/lib/apm/get_stats.js
@@ -1,0 +1,70 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import moment from 'moment';
+import { checkParam } from '../error_missing_required';
+import { createApmQuery } from './create_apm_query';
+import {
+  apmAggFilterPath,
+  apmUuidsAgg,
+  apmAggResponseHandler,
+} from './_apm_stats';
+import { getTimeOfLastEvent } from './_get_time_of_last_event';
+
+export function handleResponse(...args) {
+  const { apmTotal, totalEvents, bytesSent } = apmAggResponseHandler(...args);
+
+  return {
+    bytesSent,
+    totalEvents,
+    apms: {
+      total: apmTotal
+    }
+  };
+}
+
+export async function getStats(req, apmIndexPattern, clusterUuid) {
+  checkParam(apmIndexPattern, 'apmIndexPattern in getBeats');
+
+  const config = req.server.config();
+  const start = moment.utc(req.payload.timeRange.min).valueOf();
+  const end = moment.utc(req.payload.timeRange.max).valueOf();
+  const maxBucketSize = config.get('xpack.monitoring.max_bucket_size');
+
+  const params = {
+    index: apmIndexPattern,
+    filterPath: apmAggFilterPath,
+    size: 0,
+    ignoreUnavailable: true,
+    body: {
+      query: createApmQuery({
+        start,
+        end,
+        clusterUuid,
+      }),
+      aggs: apmUuidsAgg(maxBucketSize)
+    }
+  };
+
+  const { callWithRequest } = req.server.plugins.elasticsearch.getCluster('monitoring');
+  const [response, timeOfLastEvent] = await Promise.all([
+    callWithRequest(req, 'search', params),
+    getTimeOfLastEvent({
+      req,
+      callWithRequest,
+      apmIndexPattern,
+      start,
+      end,
+      clusterUuid
+    })
+  ]);
+
+  const formattedResponse = handleResponse(response, start, end);
+  return {
+    ...formattedResponse,
+    timeOfLastEvent,
+  };
+}

--- a/x-pack/plugins/monitoring/server/lib/apm/index.js
+++ b/x-pack/plugins/monitoring/server/lib/apm/index.js
@@ -7,3 +7,4 @@
 export { getApmsForClusters } from './get_apms_for_clusters';
 export { getStats } from './get_stats';
 export { getApms } from './get_apms';
+export { getApmInfo } from './get_apm_info';

--- a/x-pack/plugins/monitoring/server/lib/apm/index.js
+++ b/x-pack/plugins/monitoring/server/lib/apm/index.js
@@ -5,3 +5,5 @@
  */
 
 export { getApmsForClusters } from './get_apms_for_clusters';
+export { getStats } from './get_stats';
+export { getApms } from './get_apms';

--- a/x-pack/plugins/monitoring/server/lib/metrics/apm/classes.js
+++ b/x-pack/plugins/monitoring/server/lib/metrics/apm/classes.js
@@ -4,7 +4,25 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import { Metric } from '../classes';
+import { ClusterMetric, Metric } from '../classes';
+import { SMALL_FLOAT, LARGE_FLOAT } from '../../../../common/formatting';
+
+export class ApmClusterMetric extends ClusterMetric {
+  constructor(opts) {
+    super({
+      ...opts,
+      app: 'apm',
+      ...ApmClusterMetric.getMetricFields()
+    });
+  }
+
+  static getMetricFields() {
+    return {
+      uuidField: 'cluster_uuid',
+      timestampField: 'beats_stats.timestamp'
+    };
+  }
+}
 
 export class ApmMetric extends Metric {
   constructor(opts) {
@@ -19,6 +37,224 @@ export class ApmMetric extends Metric {
     return {
       uuidField: 'beats_stats.beat.uuid',
       timestampField: 'beats_stats.timestamp'
+    };
+  }
+}
+
+export class ApmSuccessResponseMetric extends ApmMetric {
+  constructor(opts) {
+    super({
+      ...opts,
+      format: SMALL_FLOAT,
+      metricAgg: 'max',
+      units: '%',
+      derivative: true
+    });
+
+    const metrics = [
+      'beats_stats.metrics.apm-server.server.response.valid.ok',
+      'beats_stats.metrics.apm-server.server.response.valid.accepted',
+    ];
+
+    this.aggs = metrics.reduce((accum, metric) => {
+      const split = metric.split('.');
+      const name = split[split.length - 1];
+      accum[name] = {
+        max: { field: metric }
+      };
+      accum[`${name}_deriv`] = {
+        derivative: { buckets_path: name, gap_policy: 'skip', unit: '1m' }
+      };
+      return accum;
+    }, {});
+
+    this.aggs = {
+      ...this.aggs,
+      metric_deriv: {
+        derivative: {
+          buckets_path: 'metric',
+          gap_policy: 'skip',
+          unit: '1m'
+        }
+      }
+    };
+
+    /*
+     * Convert a counter of milliseconds of utilization time into a percentage of the bucket size
+     */
+    this.calculation = (
+      _bucket = {},
+      _key,
+      _metric,
+    ) => {
+      if (_bucket.metric_deriv) {
+        const total = _bucket.metric_deriv.normalized_value;
+        const successes = _bucket.ok_deriv.normalized_value + _bucket.accepted_deriv.normalized_value;
+
+        if (
+          total >= 0 &&
+          total !== null
+        ) {
+          return successes / total * 100;
+        }
+      }
+      return null;
+    };
+  }
+}
+
+export class ApmFailureResponseMetric extends ApmMetric {
+  constructor(opts) {
+    super({
+      ...opts,
+      format: SMALL_FLOAT,
+      metricAgg: 'max',
+      units: '%',
+      derivative: true
+    });
+
+    const metrics = [
+      'beats_stats.metrics.apm-server.server.response.errors.toolarge',
+      'beats_stats.metrics.apm-server.server.response.errors.validate',
+      'beats_stats.metrics.apm-server.server.response.errors.method',
+      'beats_stats.metrics.apm-server.server.response.errors.unauthorized',
+      'beats_stats.metrics.apm-server.server.response.errors.ratelimit',
+      'beats_stats.metrics.apm-server.server.response.errors.queue',
+      'beats_stats.metrics.apm-server.server.response.errors.decode',
+      'beats_stats.metrics.apm-server.server.response.errors.forbidden',
+      'beats_stats.metrics.apm-server.server.response.errors.concurrency',
+      'beats_stats.metrics.apm-server.server.response.errors.closed',
+    ];
+
+    this.aggs = metrics.reduce((accum, metric) => {
+      const split = metric.split('.');
+      const name = split[split.length - 1];
+      accum[name] = {
+        max: { field: metric }
+      };
+      accum[`${name}_deriv`] = {
+        derivative: { buckets_path: name, gap_policy: 'skip', unit: '1m' }
+      };
+      return accum;
+    }, {});
+
+    this.aggs = {
+      ...this.aggs,
+      metric_deriv: {
+        derivative: {
+          buckets_path: 'metric',
+          gap_policy: 'skip',
+          unit: '1m'
+        }
+      }
+    };
+
+    /*
+     * Convert a counter of milliseconds of utilization time into a percentage of the bucket size
+     */
+    this.calculation = (
+      _bucket = {},
+      _key,
+      _metric,
+    ) => {
+      if (_bucket.metric_deriv) {
+        const total = _bucket.metric_deriv.normalized_value;
+        const failures = _bucket.toolarge_deriv.normalized_value
+          + _bucket.validate_deriv.normalized_value
+          + _bucket.method_deriv.normalized_value
+          + _bucket.unauthorized_deriv.normalized_value
+          + _bucket.ratelimit_deriv.normalized_value
+          + _bucket.queue_deriv.normalized_value
+          + _bucket.decode_deriv.normalized_value
+          + _bucket.forbidden_deriv.normalized_value
+          + _bucket.concurrency_deriv.normalized_value
+          + _bucket.closed_deriv.normalized_value;
+
+        if (
+          total >= 0 &&
+          total !== null
+        ) {
+          return failures  / total * 100;
+        }
+      }
+      return null;
+    };
+  }
+}
+
+
+export class ApmCpuUtilizationMetric extends ApmMetric {
+  constructor(opts) {
+    super({
+      ...opts,
+      format: SMALL_FLOAT,
+      metricAgg: 'max',
+      units: '%',
+      derivative: true
+    });
+
+    /*
+     * Convert a counter of milliseconds of utilization time into a percentage of the bucket size
+     */
+    this.calculation = (
+      { metric_deriv: metricDeriv } = {},
+      _key,
+      _metric,
+      bucketSizeInSeconds
+    ) => {
+      if (metricDeriv) {
+        const { normalized_value: metricDerivNormalizedValue } = metricDeriv;
+        const bucketSizeInMillis = bucketSizeInSeconds * 1000;
+
+        if (
+          metricDerivNormalizedValue >= 0 &&
+          metricDerivNormalizedValue !== null
+        ) {
+          return metricDerivNormalizedValue / bucketSizeInMillis * 100;
+        }
+      }
+      return null;
+    };
+  }
+}
+
+export class ApmEventsRateClusterMetric extends ApmClusterMetric {
+  constructor(opts) {
+    super({
+      ...opts,
+      derivative: true,
+      format: LARGE_FLOAT,
+      metricAgg: 'max',
+      units: '/m'
+    });
+
+    this.aggs = {
+      beats_uuids: {
+        terms: {
+          field: 'beats_stats.beat.uuid',
+          size: 10000
+        },
+        aggs: {
+          event_rate_per_beat: {
+            max: {
+              field: this.field
+            }
+          }
+        }
+      },
+      event_rate: {
+        sum_bucket: {
+          buckets_path: 'beats_uuids>event_rate_per_beat',
+          gap_policy: 'skip'
+        }
+      },
+      metric_deriv: {
+        derivative: {
+          buckets_path: 'event_rate',
+          gap_policy: 'skip',
+          unit: '1m'
+        }
+      }
     };
   }
 }

--- a/x-pack/plugins/monitoring/server/lib/metrics/apm/metrics.js
+++ b/x-pack/plugins/monitoring/server/lib/metrics/apm/metrics.js
@@ -4,6 +4,271 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-export const metrics = {
+import { LARGE_BYTES, LARGE_FLOAT } from '../../../../common/formatting';
+import {
+  ApmMetric,
+  ApmCpuUtilizationMetric,
+  ApmEventsRateClusterMetric,
+  ApmSuccessResponseMetric,
+  ApmFailureResponseMetric
+} from './classes';
 
+export const metrics = {
+  apm_cpu_total: new ApmCpuUtilizationMetric({
+    title: 'CPU Utilization',
+    label: 'Total',
+    description:
+      'Percentage of CPU time spent executing (user+kernel mode) for the APM process',
+    field: 'beats_stats.metrics.beat.cpu.total.value'
+  }),
+  apm_system_os_load_1: new ApmMetric({
+    field: 'beats_stats.metrics.system.load.1',
+    label: '1m',
+    title: 'System Load',
+    description: 'Load average over the last 1 minute',
+    format: LARGE_FLOAT,
+    metricAgg: 'max',
+    units: ''
+  }),
+  apm_system_os_load_5: new ApmMetric({
+    field: 'beats_stats.metrics.system.load.5',
+    label: '5m',
+    title: 'System Load',
+    description: 'Load average over the last 5 minutes',
+    format: LARGE_FLOAT,
+    metricAgg: 'max',
+    units: ''
+  }),
+  apm_system_os_load_15: new ApmMetric({
+    field: 'beats_stats.metrics.system.load.15',
+    label: '15m',
+    title: 'System Load',
+    description: 'Load average over the last 15 minutes',
+    format: LARGE_FLOAT,
+    metricAgg: 'max',
+    units: ''
+  }),
+
+  apm_mem_gc_next: new ApmMetric({
+    field: 'beats_stats.metrics.beat.memstats.gc_next',
+    label: 'GC Next',
+    title: 'Memory',
+    description:
+      'Limit of allocated memory at which garbage collection will occur',
+    format: LARGE_BYTES,
+    metricAgg: 'max',
+    units: 'B'
+  }),
+  apm_mem_total: new ApmMetric({
+    field: 'beats_stats.metrics.beat.memstats.memory_total',
+    label: 'Total Memory',
+    title: 'Memory',
+    description:
+      'Total memory',
+    format: LARGE_BYTES,
+    metricAgg: 'max',
+    units: 'B'
+  }),
+  apm_mem_alloc: new ApmMetric({
+    field: 'beats_stats.metrics.beat.memstats.memory_alloc',
+    label: 'Allocated Memory',
+    title: 'Memory',
+    description:
+      'Allocated memory',
+    format: LARGE_BYTES,
+    metricAgg: 'max',
+    units: 'B'
+  }),
+  apm_mem_rss: new ApmMetric({
+    field: 'beats_stats.metrics.beat.memstats.rss',
+    label: 'Process Total',
+    title: 'Memory',
+    description: 'Resident set size of memory reserved by the APM service from the OS',
+    format: LARGE_BYTES,
+    metricAgg: 'max',
+    units: 'B'
+  }),
+
+  apm_requests: new ApmEventsRateClusterMetric({
+    field: 'beats_stats.metrics.apm-server.server.request.count',
+    title: 'Requests',
+    label: 'Requested',
+    description: 'PLZ FILL ME IN'
+  }),
+
+  apm_responses_count: new ApmEventsRateClusterMetric({
+    field: 'beats_stats.metrics.apm-server.server.response.count',
+    title: 'Response Count',
+    label: 'Total',
+    description: 'PLZ FILL ME IN'
+  }),
+  apm_responses_success: new ApmSuccessResponseMetric({
+    field: 'beats_stats.metrics.apm-server.server.response.count',
+    title: 'Success',
+    label: 'Success',
+    description: 'PLZ FILL ME IN'
+  }),
+  apm_responses_failure: new ApmFailureResponseMetric({
+    field: 'beats_stats.metrics.apm-server.server.response.count',
+    title: 'Success Rate',
+    label: 'Failure',
+    description: 'PLZ FILL ME IN'
+  }),
+  apm_responses_valid_ok: new ApmEventsRateClusterMetric({
+    field: 'beats_stats.metrics.apm-server.server.response.valid.ok',
+    title: 'Ok',
+    label: 'Ok',
+    description: 'PLZ FILL ME IN'
+  }),
+  apm_responses_valid_accepted: new ApmEventsRateClusterMetric({
+    field: 'beats_stats.metrics.apm-server.server.response.valid.accepted',
+    title: 'Accepted',
+    label: 'Accepted',
+    description: 'PLZ FILL ME IN'
+  }),
+  apm_responses_errors_toolarge: new ApmEventsRateClusterMetric({
+    field: 'beats_stats.metrics.apm-server.server.response.errors.toolarge',
+    title: 'Response Errors',
+    label: 'Too large',
+    description: 'PLZ FILL ME IN'
+  }),
+  apm_responses_errors_validate: new ApmEventsRateClusterMetric({
+    field: 'beats_stats.metrics.apm-server.server.response.errors.validate',
+    title: 'Validate',
+    label: 'Validate',
+    description: 'PLZ FILL ME IN'
+  }),
+  apm_responses_errors_method: new ApmEventsRateClusterMetric({
+    field: 'beats_stats.metrics.apm-server.server.response.errors.method',
+    title: 'Method',
+    label: 'Method',
+    description: 'PLZ FILL ME IN'
+  }),
+  apm_responses_errors_unauthorized: new ApmEventsRateClusterMetric({
+    field: 'beats_stats.metrics.apm-server.server.response.errors.unauthorized',
+    title: 'Unauthorized',
+    label: 'Unauthorized',
+    description: 'PLZ FILL ME IN'
+  }),
+  apm_responses_errors_ratelimit: new ApmEventsRateClusterMetric({
+    field: 'beats_stats.metrics.apm-server.server.response.errors.ratelimit',
+    title: 'Rate limit',
+    label: 'Rate limit',
+    description: 'PLZ FILL ME IN'
+  }),
+  apm_responses_errors_queue: new ApmEventsRateClusterMetric({
+    field: 'beats_stats.metrics.apm-server.server.response.errors.queue',
+    title: 'Queue',
+    label: 'Queue',
+    description: 'PLZ FILL ME IN'
+  }),
+  apm_responses_errors_decode: new ApmEventsRateClusterMetric({
+    field: 'beats_stats.metrics.apm-server.server.response.errors.decode',
+    title: 'Decode',
+    label: 'Decode',
+    description: 'PLZ FILL ME IN'
+  }),
+  apm_responses_errors_forbidden: new ApmEventsRateClusterMetric({
+    field: 'beats_stats.metrics.apm-server.server.response.errors.forbidden',
+    title: 'Forbidden',
+    label: 'Forbidden',
+    description: 'PLZ FILL ME IN'
+  }),
+  apm_responses_errors_concurrency: new ApmEventsRateClusterMetric({
+    field: 'beats_stats.metrics.apm-server.server.response.errors.concurrency',
+    title: 'Concurrency',
+    label: 'Concurrency',
+    description: 'PLZ FILL ME IN'
+  }),
+  apm_responses_errors_closed: new ApmEventsRateClusterMetric({
+    field: 'beats_stats.metrics.apm-server.server.response.errors.closed',
+    title: 'Closed',
+    label: 'Closed',
+    description: 'PLZ FILL ME IN'
+  }),
+
+  apm_decoder_deflate_contentlength: new ApmMetric({
+    field: 'beats_stats.metrics.apm-server.decoder.deflate.content-length',
+    label: 'Deflater',
+    title: 'Incoming Requests Size',
+    description: 'PLZ FILL ME IN',
+    format: LARGE_BYTES,
+    metricAgg: 'max',
+    units: 'B'
+  }),
+  apm_decoder_gzip_contentlength: new ApmMetric({
+    field: 'beats_stats.metrics.apm-server.decoder.gzip.content-length',
+    label: 'Gzip',
+    title: 'Gzip',
+    description: 'PLZ FILL ME IN',
+    format: LARGE_BYTES,
+    metricAgg: 'max',
+    units: 'B'
+  }),
+  apm_decoder_uncompressed_contentlength: new ApmMetric({
+    field: 'beats_stats.metrics.apm-server.decoder.uncompressed.content-length',
+    label: 'Uncompressed',
+    title: 'Uncompressed',
+    description: 'PLZ FILL ME IN',
+    format: LARGE_BYTES,
+    metricAgg: 'max',
+    units: 'B'
+  }),
+
+  apm_processor_transaction_transformations: new ApmEventsRateClusterMetric({
+    field: 'beats_stats.metrics.apm-server.processor.transaction.transformations',
+    title: 'Transformations',
+    label: 'Transaction',
+    description: 'PLZ FILL ME IN'
+  }),
+  apm_processor_span_transformations: new ApmEventsRateClusterMetric({
+    field: 'beats_stats.metrics.apm-server.processor.span.transformations',
+    title: 'Transformations',
+    label: 'Span',
+    description: 'PLZ FILL ME IN'
+  }),
+  apm_processor_error_transformations: new ApmEventsRateClusterMetric({
+    field: 'beats_stats.metrics.apm-server.processor.error.transformations',
+    title: 'Transformations',
+    label: 'Error',
+    description: 'PLZ FILL ME IN'
+  }),
+  apm_processor_metric_transformations: new ApmEventsRateClusterMetric({
+    field: 'beats_stats.metrics.apm-server.processor.metric.transformations',
+    title: 'Transformations',
+    label: 'Metric',
+    description: 'PLZ FILL ME IN'
+  }),
+
+
+  apm_output_events_total: new ApmEventsRateClusterMetric({
+    field: 'beats_stats.metrics.libbeat.output.events.total',
+    title: 'Output Events Rate',
+    label: 'Total',
+    description: 'Events processed by the output (including retries)'
+  }),
+  apm_output_events_failed: new ApmEventsRateClusterMetric({
+    field: 'beats_stats.metrics.libbeat.output.events.failed',
+    title: 'Output Failed Events Rate',
+    label: 'Failed',
+    description: 'Events processed by the output (including retries)'
+  }),
+  apm_output_events_dropped: new ApmEventsRateClusterMetric({
+    field: 'beats_stats.metrics.libbeat.output.events.dropped',
+    title: 'Output Dropped Events Rate',
+    label: 'Dropped',
+    description: 'Events processed by the output (including retries)'
+  }),
+  apm_output_events_active: new ApmEventsRateClusterMetric({
+    field: 'beats_stats.metrics.libbeat.output.events.active',
+    title: 'Output Active Events Rate',
+    label: 'Active',
+    description: 'Events processed by the output (including retries)'
+  }),
+  apm_output_events_acked: new ApmEventsRateClusterMetric({
+    field: 'beats_stats.metrics.libbeat.output.events.acked',
+    title: 'Output Acked Events Rate',
+    label: 'Acked',
+    description: 'Events processed by the output (including retries)'
+  }),
 };

--- a/x-pack/plugins/monitoring/server/routes/api/v1/apm/_get_apm_cluster_status.js
+++ b/x-pack/plugins/monitoring/server/routes/api/v1/apm/_get_apm_cluster_status.js
@@ -1,0 +1,14 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { get } from 'lodash';
+import { getApmsForClusters } from '../../../../lib/apm/get_apms_for_clusters';
+
+export const getApmClusterStatus = (req, apmIndexPattern, { clusterUuid }) => {
+  const clusters = [{ cluster_uuid: clusterUuid }];
+  return getApmsForClusters(req, apmIndexPattern, clusters)
+    .then(apms => get(apms, '[0].stats'));
+};

--- a/x-pack/plugins/monitoring/server/routes/api/v1/apm/instance.js
+++ b/x-pack/plugins/monitoring/server/routes/api/v1/apm/instance.js
@@ -9,6 +9,7 @@ import { prefixIndexPattern } from '../../../../lib/ccs_utils';
 import { getMetrics } from '../../../../lib/details/get_metrics';
 import { metricSet } from './metric_set_overview';
 import { handleError } from '../../../../lib/errors';
+import { getApmInfo } from '../../../../lib/apm';
 
 export function apmInstanceRoute(server) {
   server.route({
@@ -30,18 +31,21 @@ export function apmInstanceRoute(server) {
       }
     },
     async handler(req, reply) {
-      const beatUuid = req.params.beatUuid;
+      const apmUuid = req.params.apmUuid;
       const config = server.config();
+      const clusterUuid = req.params.clusterUuid;
       const ccs = req.payload.ccs;
-      const beatsIndexPattern = prefixIndexPattern(config, 'xpack.monitoring.beats.index_pattern', ccs);
+      const apmIndexPattern = prefixIndexPattern(config, 'xpack.monitoring.beats.index_pattern', ccs);
 
       try {
-        const [ metrics ] = await Promise.all([
-          getMetrics(req, beatsIndexPattern, metricSet, [{ term: { 'beats_stats.beat.uuid': beatUuid } }]),
+        const [ metrics, apmSummary ] = await Promise.all([
+          getMetrics(req, apmIndexPattern, metricSet, [{ term: { 'beats_stats.beat.uuid': apmUuid } }]),
+          getApmInfo(req, apmIndexPattern, { clusterUuid, apmUuid }),
         ]);
 
         reply({
           metrics,
+          apmSummary,
         });
       } catch (err) {
         reply(handleError(err, req));

--- a/x-pack/plugins/monitoring/server/routes/api/v1/apm/instances.js
+++ b/x-pack/plugins/monitoring/server/routes/api/v1/apm/instances.js
@@ -6,7 +6,7 @@
 
 import Joi from 'joi';
 import { prefixIndexPattern } from '../../../../lib/ccs_utils';
-import { getStats } from '../../../../lib/beats';
+import { getStats, getApms } from '../../../../lib/apm';
 import { handleError } from '../../../../lib/errors';
 
 export function apmInstancesRoute(server) {
@@ -35,12 +35,14 @@ export function apmInstancesRoute(server) {
 
       try {
 
-        const [ stats ] = await Promise.all([
+        const [ stats, apms ] = await Promise.all([
           getStats(req, apmIndexPattern, clusterUuid),
+          getApms(req, apmIndexPattern, clusterUuid),
         ]);
 
         reply({
           stats,
+          apms
         });
 
       } catch (err) {

--- a/x-pack/plugins/monitoring/server/routes/api/v1/apm/metric_set_instance.js
+++ b/x-pack/plugins/monitoring/server/routes/api/v1/apm/metric_set_instance.js
@@ -5,5 +5,83 @@
  */
 
 export const metricSet = [
-
+  {
+    name: 'apm_cpu',
+    keys: [
+      'apm_cpu_total'
+    ]
+  },
+  {
+    keys: [
+      'apm_system_os_load_1',
+      'apm_system_os_load_5',
+      'apm_system_os_load_15'
+    ],
+    name: 'apm_os_load'
+  },
+  {
+    keys: ['apm_mem_total', 'apm_mem_alloc', 'apm_mem_rss', 'apm_mem_gc_next'],
+    name: 'apm_memory'
+  },
+  {
+    keys: [
+      'apm_output_events_total',
+      'apm_output_events_failed',
+      'apm_output_events_dropped',
+      'apm_output_events_active',
+      'apm_output_events_acked'
+    ],
+    name: 'apm_output_events_rate'
+  },
+  {
+    keys: ['apm_responses_failure', 'apm_responses_success'],
+    name: 'apm_responses_success_failure'
+  },
+  {
+    keys: [
+      'apm_responses_count',
+      'apm_responses_valid_ok',
+      'apm_responses_valid_accepted'
+    ],
+    name: 'apm_responses_valid'
+  },
+  {
+    keys: [
+      // 'apm_responses_count',
+      'apm_responses_errors_toolarge',
+      'apm_responses_errors_validate',
+      'apm_responses_errors_method',
+      'apm_responses_errors_unauthorized',
+      'apm_responses_errors_ratelimit',
+      'apm_responses_errors_queue',
+      'apm_responses_errors_decode',
+      'apm_responses_errors_forbidden',
+      'apm_responses_errors_concurrency',
+      'apm_responses_errors_closed',
+    ],
+    name: 'apm_responses_errors'
+  },
+  {
+    keys: [
+      'apm_requests'
+    ],
+    name: 'apm_requests'
+  },
+  {
+    keys: [
+      'apm_decoder_deflate_contentlength',
+      'apm_decoder_gzip_contentlength',
+      'apm_decoder_uncompressed_contentlength'
+    ],
+    name: 'apm_incoming_requests_size'
+  },
+  {
+    keys: [
+      'apm_processor_transaction_transformations',
+      'apm_processor_span_transformations',
+      'apm_processor_error_transformations',
+      'apm_processor_metric_transformations',
+    ],
+    name: 'apm_transformations'
+  }
 ];

--- a/x-pack/plugins/monitoring/server/routes/api/v1/apm/metric_set_overview.js
+++ b/x-pack/plugins/monitoring/server/routes/api/v1/apm/metric_set_overview.js
@@ -5,4 +5,83 @@
  */
 
 export const metricSet = [
+  {
+    name: 'apm_cpu',
+    keys: [
+      'apm_cpu_total'
+    ]
+  },
+  {
+    keys: [
+      'apm_system_os_load_1',
+      'apm_system_os_load_5',
+      'apm_system_os_load_15'
+    ],
+    name: 'apm_os_load'
+  },
+  {
+    keys: ['apm_mem_total', 'apm_mem_alloc', 'apm_mem_rss', 'apm_mem_gc_next'],
+    name: 'apm_memory'
+  },
+  {
+    keys: [
+      'apm_output_events_total',
+      'apm_output_events_failed',
+      'apm_output_events_dropped',
+      'apm_output_events_active',
+      'apm_output_events_acked'
+    ],
+    name: 'apm_output_events_rate'
+  },
+  {
+    keys: ['apm_responses_failure', 'apm_responses_success'],
+    name: 'apm_responses_success_failure'
+  },
+  {
+    keys: [
+      'apm_responses_count',
+      'apm_responses_valid_ok',
+      'apm_responses_valid_accepted'
+    ],
+    name: 'apm_responses_valid'
+  },
+  {
+    keys: [
+      // 'apm_responses_count',
+      'apm_responses_errors_toolarge',
+      'apm_responses_errors_validate',
+      'apm_responses_errors_method',
+      'apm_responses_errors_unauthorized',
+      'apm_responses_errors_ratelimit',
+      'apm_responses_errors_queue',
+      'apm_responses_errors_decode',
+      'apm_responses_errors_forbidden',
+      'apm_responses_errors_concurrency',
+      'apm_responses_errors_closed',
+    ],
+    name: 'apm_responses_errors'
+  },
+  {
+    keys: [
+      'apm_requests'
+    ],
+    name: 'apm_requests'
+  },
+  {
+    keys: [
+      'apm_decoder_deflate_contentlength',
+      'apm_decoder_gzip_contentlength',
+      'apm_decoder_uncompressed_contentlength'
+    ],
+    name: 'apm_incoming_requests_size'
+  },
+  {
+    keys: [
+      'apm_processor_transaction_transformations',
+      'apm_processor_span_transformations',
+      'apm_processor_error_transformations',
+      'apm_processor_metric_transformations',
+    ],
+    name: 'apm_transformations'
+  }
 ];

--- a/x-pack/plugins/monitoring/server/routes/api/v1/apm/overview.js
+++ b/x-pack/plugins/monitoring/server/routes/api/v1/apm/overview.js
@@ -6,10 +6,10 @@
 
 import Joi from 'joi';
 import { prefixIndexPattern } from '../../../../lib/ccs_utils';
-import { getStats } from '../../../../lib/beats';
 import { getMetrics } from '../../../../lib/details/get_metrics';
 import { metricSet } from './metric_set_overview';
 import { handleError } from '../../../../lib/errors';
+import { getApmClusterStatus } from './_get_apm_cluster_status';
 
 export function apmOverviewRoute(server) {
   server.route({
@@ -40,7 +40,7 @@ export function apmOverviewRoute(server) {
           stats,
           metrics,
         ] = await Promise.all([
-          getStats(req, apmIndexPattern, clusterUuid),
+          getApmClusterStatus(req, apmIndexPattern, { clusterUuid }),
           getMetrics(req, apmIndexPattern, metricSet),
         ]);
 


### PR DESCRIPTION
Continuation of #22453

This PR introduces a monitoring UI for monitoring APM.

Here is a list of what we are currently showing in each page:

## Cluster Overview
#### `Total Events`
The difference between the `min` and `max` of `beats_stats.metrics.libbeat.pipeline.events.total`

#### `Bytes Sent`
The difference between the `min` and `max` of `beats_stats.metrics.libbeat.output.write.bytes`

## APM Overview
#### `Servers`
The number of unique uuids we have (or, the number of different apm server instances)

#### `Last Event`
The timestamp of the last monitoring document where `beats_stats.metrics.libbeat.output.events.acked > 0`

#### `CPU Utilization` graph
Based off `beats_stats.metrics.beat.cpu.total.value`

#### `System Load` graph
Based off `beats_stats.metrics.system.load.1`, `beats_stats.metrics.system.load.5`, `beats_stats.metrics.system.load.15`

#### `Output Events Rate (/m)` graph
Based off `beats_stats.metrics.libbeat.output.events.total`, `beats_stats.metrics.libbeat.output.events.failed`, `beats_stats.metrics.libbeat.output.events.dropped`, `beats_stats.metrics.libbeat.output.events.active`, and `beats_stats.metrics.libbeat.output.events.acked`. We should expect to see the `Total` and `Acked` as nearly equivalent lines.

#### `Requests (/m)` graph
Based off `beats_stats.metrics.apm-server.server.request.count`

#### `Incoming Requests Size (KB)` graph
Based off `beats_stats.metrics.apm-server.decoder.deflate.content-length`, `beats_stats.metrics.apm-server.decoder.gzip.content-length` and `beats_stats.metrics.apm-server.decoder.uncompressed.content-length`.

#### `Memory (MB)` graph
Based off `beats_stats.metrics.beat.memstats.gc_next`, `beats_stats.metrics.beat.memstats.memory_total`, `beats_stats.metrics.beat.memstats.memory_alloc`, and `beats_stats.metrics.beat.memstats.rss`

#### `Transformations (/m)` graph
Based off `beats_stats.metrics.apm-server.processor.transaction.transformations`, `beats_stats.metrics.apm-server.processor.span.transformations`, `beats_stats.metrics.apm-server.processor.error.transformations` and `beats_stats.metrics.apm-server.processor.metric.transformations`

#### `Success Rate (%)` graph
Based off `beats_stats.metrics.apm-server.server.response.valid.*` and `beats_stats.metrics.apm-server.server.response.errors.*`

